### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A Model Context Protocol (MCP) server that scrapes flight information from Bing 
 
 **📦 [View on PyPI](https://pypi.org/project/bing-flights-mcp/)**
 
+<a href="https://glama.ai/mcp/servers/@chonseng/bing-flights-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@chonseng/bing-flights-mcp/badge" alt="Bing Flights Server MCP server" />
+</a>
+
 ## Features
 
 - 🔍 Search for one-way and round-trip flights


### PR DESCRIPTION
This PR adds a badge for the [Bing Flights MCP Server](https://glama.ai/mcp/servers/@chonseng/bing-flights-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@chonseng/bing-flights-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@chonseng/bing-flights-mcp/badge" alt="Bing Flights Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.